### PR TITLE
1주차 알고리즘 문제 풀이 - 이준희

### DIFF
--- a/src/juni/boj/array/_1475/Main.java
+++ b/src/juni/boj/array/_1475/Main.java
@@ -1,0 +1,38 @@
+package juni.boj.array._1475;
+
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int[] numbers = new int[10];
+        int max=0;
+        String input = sc.nextLine();
+        String[] numArr = input.split("");
+        for(int i=0;i<input.length();i++){
+            numbers[Integer.parseInt(numArr[i])]++;
+        }
+        for(int i=0;i<numbers.length;i++){
+            if(i==6||i==9){
+                continue;
+            }
+            if(max<numbers[i]){
+                max = numbers[i];
+            }
+        }
+
+        int tmpMax = Math.max(numbers[6],numbers[9]);
+        int tmpMin = Math.min(numbers[6],numbers[9]);
+        if(max>=tmpMax){
+            System.out.println(max);
+            return;
+        }else {
+            if(max*2<=tmpMax){
+                max = tmpMin + (tmpMax-tmpMin)/2 + (tmpMax-tmpMin)%2;
+                System.out.println(max);
+                return;
+            }
+            System.out.println(max);
+        }
+    }
+}

--- a/src/juni/boj/array/_2577/Main.java
+++ b/src/juni/boj/array/_2577/Main.java
@@ -1,0 +1,20 @@
+package juni.boj.array._2577;
+
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int result = 0;
+        result = sc.nextInt()*sc.nextInt()*sc.nextInt();
+        String resultStr = String.valueOf(result);
+        String[] resultsStr = resultStr.split("");
+        int[] results = new int[10];
+        for(String r : resultsStr){
+            results[Integer.parseInt(r)]++;
+        }
+        for(int r : results){
+            System.out.println(r);
+        }
+    }
+}

--- a/src/juni/boj/array/_3273/Main.java
+++ b/src/juni/boj/array/_3273/Main.java
@@ -1,0 +1,40 @@
+package juni.boj.array._3273;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        st = new StringTokenizer(br.readLine());
+        int[] arr = new int[n];
+        for(int i=0;i<n;i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int x = Integer.parseInt(br.readLine());
+        int result = 0;
+        Arrays.sort(arr);
+        int start =0;
+        int end = n-1;
+
+        while(start<end){
+            int cal = arr[start]+arr[end];
+            if(cal>x){
+                end--;
+            }else if(cal<x){
+                start++;
+            }else{
+                result++;
+                start++;
+            }
+        }
+        System.out.println(result);
+    }
+}
+

--- a/src/juni/boj/list/_1158/Main.java
+++ b/src/juni/boj/list/_1158/Main.java
@@ -1,0 +1,34 @@
+package juni.boj.list._1158;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        Queue<Integer> q = new LinkedList<>();
+        for(int i=1;i<=n;i++){
+            q.offer(i);
+        }
+
+        System.out.print("<");
+        while(!q.isEmpty()){
+            if(q.size()==1){
+                System.out.print(q.poll());
+            }else {
+                for(int i=0;i<k-1;i++){
+                    q.offer(q.poll());
+                }
+                int a = q.poll();
+                System.out.print(a+", ");
+            }
+        }
+        System.out.println(">");
+
+    }
+}

--- a/src/juni/boj/list/_5397/Main.java
+++ b/src/juni/boj/list/_5397/Main.java
@@ -1,0 +1,49 @@
+package juni.boj.list._5397;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < t; i++) {
+            List<String> linkedList = new LinkedList<>();
+            String sentence = br.readLine();
+            String[] sentences = sentence.split("");
+            /*
+            새로 알게된 개념 : ListIterator
+            List 전용 Iterator로 양방향으로 탐색이 가능한것이 특징이다.
+            cursor의 위치는 요소를 가리키고 있는 것이 아닌 요소와 요소 사이에 있다.
+             */
+            ListIterator<String> iter = linkedList.listIterator();
+
+            for (int j = 0; j < sentences.length; j++) {
+                if (sentences[j].equals("<")) {
+                    if (iter.hasPrevious()) {
+                        iter.previous();
+                    }
+                } else if (sentences[j].equals(">")) {
+                    if (iter.hasNext()) {
+                        iter.next();
+                    }
+                } else if (sentences[j].equals("-")) {
+                    if (iter.hasPrevious()) {
+                        iter.previous();
+                        iter.remove();
+                    }
+                }else{
+                    iter.add(sentences[j]);
+                }
+            }
+            StringBuilder sb = new StringBuilder();
+            for(String s : linkedList){
+                sb.append(s);
+            }
+            System.out.println(sb);
+        }
+    }
+}


### PR DESCRIPTION
### 문제: BOJ2577 - 숫자의 개수
#### 🐣[풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/commit/4986324f19b00cd4e0b586c0a30ed494235502f7) 
시간복잡도: O(n)
문자열의 길이에 따라 루프문을 반복하므로 O(n)
세 정수 A, B, C를 입력 받고, 이들의 곱을 계산한다.
한글자씩 나누어 1-9사이의 배열에 해당 글자를 숫자로 변환하여 해당 index값을 증가시켜 출력한다. 
* * *
### 문제: BOJ1475 - 방 번호
#### 🐣[풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/commit/736911bb3dde03d84466ab428ba5a30ad7f4a037) 
시간복잡도: O(n)
숫자의 길이에 따라 루프문을 반복하므로 O(n)
6,9를 제외한 숫자의 Max값을 구한후,
6,9를 비교하여 큰값과 작은값을 tmpMax,tmpMin 에 담는다.
6,9를 제외한 숫자 즉  Max 가 6,9개수 tmpMax 보다 많으면 그냥 Max가 결과값
max*2 보다도 tmpMax가 크면 6,9의 개수가 더 많은것이므로
결과값은 6,9중 적은 값 + 두 수의 개수차이/2 + 두 수의 개수 차이%2가 결과가된다.
 * * *
### 문제: BOJ3273 - 두 수의 합
#### 🐣[풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/commit/ab6d73399af47e43afa9c6dfd4034e5627a54d21) 
시간복잡도: O(n)
배열 탐색 한번만 하기 때문에 O(n)
수열이 초기화된 배열을 오름차순으로 정렬한다.
두개의 포인터(start,end)를 사용하여 배열을 순회한다.
합이 같으면 start,result를 증가시키고, 합이 크면 end 포인터를 감소, 작으면 start 포인터를 증가 
탐색이 끝나면 result를 출력한다.
* * *
### 문제: BOJ5397 - 키로거
#### 🐣[풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/commit/49c3fdf0d42ca0a877409367e9473fcc1789b1c2) 
시간복잡도: O(n)
시간초과때문에 결국 포기하고 정답보고 진행
키 입력을 순차적으로 처리하므로 O(n) 
시간제한이 짧기때문에, 삽입 삭제시 유리한 LinkedList 선택

그러나 탐색을 진행하면 O(n)이라는 복잡도를 가져, 초과가 나기때문에 ListIterator 개념 학습 후 사용
근데 그래도 시간초과가나서 StringBuilder를 이용해 한번에 출력하여 시간을 줄였다.
System.out.println를 반복적으로 사용하면 성능차이가 많이난다는것을 알게되었다.
* * *
### 문제: BOJ1158 - 요세푸스 문제
#### 🐣[풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/commit/ceeb895ce2804fa714534660254252266cde10df) 
시간복잡도: O(n) 
삽입 삭제 O(1) * 반복횟수이기때문에
선출된것을 그대로 삽입하여 정답을 구할것이기 때문에 Queue 를 이용.
k번째 전까지는 그대로 삭제후 다시 삽입하고, k번째에는 출력하는 방식으로 풀었다.

