### PR TITLE
2주차 알고리즘 문제 풀이(2) - 송헌욱 

### DIFF
--- a/src/heonuk/boj/stack_queue_deque/_1021/Main.java
+++ b/src/heonuk/boj/stack_queue_deque/_1021/Main.java
@@ -1,0 +1,47 @@
+package heonuk.boj.stack_queue_deque._1021;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class Main {
+
+    public static int solution(int n, int m, int[] data) {
+        int result = 0;
+
+        Deque<Integer> deque = new LinkedList<>();
+        for (int i = 1; i <= n; i++) {
+            deque.add(i);
+        }
+
+        for (int i = 0; i < m; i++) {
+            int target = data[i]; // 현재 회전 연산의 목표 값
+            int count = 0; // 회전 횟수를 초기화
+
+            while (deque.peek() != null && target != deque.peek()) {
+                deque.add(deque.poll());
+                count++;
+            }
+
+            result += Math.min(count, deque.size() - count);
+            deque.poll();
+        }
+
+        return result;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] line1 = br.readLine().split(" ");
+        int n = Integer.parseInt(line1[0]); // 큐의 크기
+        int m = Integer.parseInt(line1[1]); // 뽑아 내려고 하는 수의 개수
+        int[] data = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        System.out.println(solution(n, m, data));
+    }
+
+}

--- a/src/heonuk/boj/stack_queue_deque/_2164/Main.java
+++ b/src/heonuk/boj/stack_queue_deque/_2164/Main.java
@@ -1,0 +1,32 @@
+package heonuk.boj.stack_queue_deque._2164;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class Main {
+
+    public static int solution(int n) {
+        Deque<Integer> deque = new LinkedList<>();
+
+        for (int i = 1; i <= n; i++) {
+            deque.add(i);
+        }
+
+        while (deque.size() != 1) {
+            deque.removeFirst();
+            deque.addLast(deque.poll());
+        }
+
+        return deque.pop();
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        System.out.println(solution(n));
+    }
+
+}

--- a/src/heonuk/boj/stack_queue_deque/_3986/Main.java
+++ b/src/heonuk/boj/stack_queue_deque/_3986/Main.java
@@ -1,0 +1,42 @@
+package heonuk.boj.stack_queue_deque._3986;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Main {
+
+    public static int solution(int n, String[] words) {
+        int result = 0;
+        for (String word : words) {
+            if (isGood(word)) {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    public static boolean isGood(String word) {
+        Stack<Character> stack = new Stack<>();
+        for (char c : word.toCharArray()) {
+            if (!stack.isEmpty() && stack.peek() == c) {
+                stack.pop();
+            } else {
+                stack.push(c);
+            }
+        }
+        return stack.isEmpty();
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        String[] words = new String[n];
+        for (int i = 0; i < n; i++) {
+            words[i] = br.readLine();
+        }
+        System.out.println(solution(n, words));
+    }
+
+}


### PR DESCRIPTION
## 문제: BOJ2164 - 카드 2
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/21/commits/b4ffa4f835eab4b393fa8cebdab3bbbc85959209) 👨🏻‍💻

- 시간복잡도: **O(n)**
각 숫자를 덱(Deque)에 추가하고, 명령에 따라서 순차적으로 연산을 수행하며 **한번** 순회하기 때문
- 자바에서는 `Deque`를 이용하여 큐(Queue) 연산을 수행한다.
- 1부터 n까지(n포함)의 숫자를 `Deque`에 추가한다. (`i = 1; i <= n; i++`)
- `Deque`의 크기가 1이 될 때까지 반복문을 사용한다. → 첫 번째 요소를 제거한다.(`removeFirst`) → 두 번째 요소를 마지막으로 이동시킨다.
(뺀걸 다시 넣기; `addLast(deque.poll())`)
- 마지막으로 남은 요소를 반환한다.

---

## 문제: BOJ1021 - 회전하는 큐
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/21/commits/634673e43532a70bf0efd37dc356c20517e23db8) 👨🏻‍💻

![image](https://github.com/SysoneEduTeam4/Algorithm/assets/117193889/4a7cb62d-b536-4325-a806-50195226846f)

- 시간복잡도: **O(n * m) ; (for 문 안에 while 문)**
각 목표 숫자를 찾기 위해 n번의 순회를 한다. 그리고 m번의 반복을 추가로 필요하다.
- 1부터 n까지의 숫자를 `Deque`에 추가한다.
- 각 목표 숫자에 대해 회전 연산을 수행하여 목표 숫자를 `Deque`의 맨 앞에 위치시키고, 회전 횟수를 누적한다.
(여기서 왼쪽, 오른쪽 한방향을 기준으로 잡고, 기준 잡은 방향에서의 수를 deque안에 남은 요소의 수에서 빼면 반대로 회전했을 때의 회수가 나오게된다. 그중 작은 값을 선택해야 최소 거리의 수가 된다.)
- 목표 숫자를 `Deque`에서 제거하고, 최종 누적된 회전 횟수를 반환한다.

---

## 문제: BOJ3986 - 좋은 단어
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/21/commits/b0f41c3db47958a71093556dd2f8cc51df277e80) 👨🏻‍💻

- 시간복잡도: **O(n2)**
words 배열을 전체 순회하고 좋은 단어인지 확인하기 위해 검증(`isGood` 메서드)하는 과정에서 최악의 경우 n2이 된다.
- 자바에서는 `Stack`을 이용하여 문자 짝 검사 연산을 수행한다.
- `isGood(String word)` 메서드: 각 단어에 대해 문자의 짝을 검사하여 올바른 문자열인지 확인한다.
짝은 스택을 통해 가장 위에 들어간 값이 들어갈 문자와 같다면 들어간 값을 제거해주면서, stack에 아무것도 남지 않게 되면 좋은 단어로 판단한다.
- 올바른 문자열의 개수를 세고, 최종 결과를 반환한다.