### PR TITLE
3주차 알고리즘 문제 풀이(2) - 송헌욱

### DIFF
--- a/src/heonuk/boj/bfs/_10026/Main.java
+++ b/src/heonuk/boj/bfs/_10026/Main.java
@@ -1,0 +1,89 @@
+package heonuk.boj.bfs._10026;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Main {
+
+    static char[][] grid;
+    static boolean[][] visited;
+    static int[] dx = {0, -1, 0, 1}, dy = {-1, 0, 1, 0};
+    static int cntR, cntG, cntB, cntRG;
+
+    public static void bfs(int col, int row, char color1, char color2) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{col, row});
+
+        while (!queue.isEmpty()) {
+            int x = queue.peek()[0];
+            int y = queue.peek()[1];
+            visited[x][y] = true;
+            queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int curX = dx[i] + x;
+                int curY = dy[i] + y;
+
+                if (curX >= 0 && curY >= 0 && curX < grid.length && curY < grid.length) {
+                    if ((grid[curX][curY] == color1 || grid[curX][curY] == color2)
+                            && !visited[curX][curY]) {
+                        queue.add(new int[]{curX, curY});
+                        visited[curX][curY] = true;
+                    }
+                }
+            }
+
+        }
+    }
+
+    public static String solution(int N) {
+        StringBuilder result = new StringBuilder();
+        visited = new boolean[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (grid[i][j] == 'R' && !visited[i][j]) {
+                    bfs(i, j, 'R', 'R');
+                    cntR++;
+                    continue;
+                }
+
+                if (grid[i][j] == 'G' && !visited[i][j]) {
+                    bfs(i, j, 'G', 'G');
+                    cntG++;
+                    continue;
+                }
+
+                if (grid[i][j] == 'B' && !visited[i][j]) {
+                    bfs(i, j, 'B', 'B');
+                    cntB++;
+                    continue;
+                }
+            }
+        }
+        visited = new boolean[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if ((grid[i][j] == 'R' || grid[i][j] == 'G') && !visited[i][j]) {
+                    bfs(i, j, 'R', 'G');
+                    cntRG++;
+                }
+            }
+        }
+        result.append(cntR + cntG + cntB).append(' ').append(cntRG + cntB);
+        return result.toString();
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        grid = new char[N][N];
+        for (int i = 0; i < N; i++) {
+            grid[i] = br.readLine().toCharArray();
+        }
+        System.out.println(solution(N));
+    }
+
+}

--- a/src/heonuk/boj/bfs/_1012/Main.java
+++ b/src/heonuk/boj/bfs/_1012/Main.java
@@ -1,0 +1,77 @@
+package heonuk.boj.bfs._1012;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Main {
+
+    static int N, M, K, count;
+    static int[][] ground;
+    static boolean[][] visited;
+    static int[] dx = {0, -1, 0, 1};
+    static int[] dy = {1, 0, -1, 0};
+
+    static void bfs(int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{x, y});
+
+        while (!queue.isEmpty()) {
+            x = queue.peek()[0];
+            y = queue.peek()[1];
+            visited[x][y] = true;
+            queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int curX = x + dx[i];
+                int curY = y + dy[i];
+
+                if (curX >= 0 && curY >= 0 && curX < M && curY < N) {
+                    if (ground[curX][curY] == 1 && !visited[curX][curY]) {
+                        queue.add(new int[]{curX, curY});
+                        visited[curX][curY] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder result = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        for (int testCase = 0; testCase < T; testCase++) {
+            String[] matrixInfo = br.readLine().split(" ");
+            M = Integer.parseInt(matrixInfo[0]);
+            N = Integer.parseInt(matrixInfo[1]);
+            K = Integer.parseInt(matrixInfo[2]);
+
+            ground = new int[M][N];
+            visited = new boolean[M][N];
+            count = 0;
+
+            for (int coordinate = 0; coordinate < K; coordinate++) {
+                String[] coordinateInfo = br.readLine().split(" ");
+                int x = Integer.parseInt(coordinateInfo[0]);
+                int y = Integer.parseInt(coordinateInfo[1]);
+                ground[x][y] = 1;
+            }
+
+            for (int i = 0; i < M; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (ground[i][j] == 1 && !visited[i][j]) {
+                        bfs(i, j);
+                        count++;
+                    }
+                }
+            }
+
+            result.append(count).append("\n");
+        }
+
+        System.out.println(result);
+    }
+
+}

--- a/src/heonuk/boj/hash/_9375/Main.java
+++ b/src/heonuk/boj/hash/_9375/Main.java
@@ -1,0 +1,43 @@
+package heonuk.boj.hash._9375;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Main {
+
+    public static int solution(int n, String[] items) {
+        Map<String, Integer> map = new HashMap<>();
+        for (String item : items) {
+            String[] data = item.split(" ");
+            if (map.containsKey(data[1])) {
+                map.put(data[1], map.get(data[1]) + 1);
+            } else { // 새로운 종류
+                map.put(data[1], 1);
+            }
+        }
+
+        int result = 1;
+        for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            result = result * (entry.getValue() + 1);
+        }
+        return result - 1;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder result = new StringBuilder();
+        int testCase = Integer.parseInt(br.readLine());
+        for (int i = 0; i < testCase; i++) {
+            int n = Integer.parseInt(br.readLine());
+            String[] items = new String[n];
+            for (int j = 0; j < n; j++) {
+                items[j] = br.readLine();
+            }
+            result.append(solution(n, items)).append("\n");
+        }
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 문제: BOJ9375 - 패션왕 신해빈
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/26/commits/7d352f008f558d2aa6dfb3b0363812c825c56174) 👨🏻‍💻

- 시간복잡도: **O(n)**
  아이템 개수 N개에 대해 해시맵에 삽입하는 작업
- 각 종류별 아이템의 수를 해시맵에 저장한다.
- 모든 종류의 아이템 수 +1 (아이템을 선택하지 않는 경우인 none을 포함)을 곱한 후, 아무 것도 선택하지 않는 경우 1을 뺀다.

---

## 문제: BOJ1012 - 유기농 배추
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/26/commits/4e1d0911c0145ffd55a69b009a0a9f5d14791fdc) 👨🏻‍💻
- 시간복잡도: **O(n^2)** 
  2차원 배열을 순회하는 방법으로 2차원 배열 크기를 모두 순회하기 때문
- BFS 너비 우선 탐색으로 상하좌우 해당 조건에 맞으면 Queue에 담아서 계속 탐색한다.
- 사방이 0이되면 count를 증가시키고 다시 방문하지 않은 배추(1)를 찾으며 이를 반복한다.

---

## 문제: BOJ10026 - 적록색약
### [풀이 방법](https://github.com/SysoneEduTeam4/Algorithm/pull/26/commits/b8185918c97520145dbb80cb4487f8ae4000d2f4) 👨🏻‍💻
- 시간복잡도: **O(n^2)** 
  2차원 배열을 순회하는 방법으로 2차원 배열 크기를 모두 순회하기 때문
- 유기농 배추와 동일한 BFS 문제 풀이 방법이지만, 다른 조건으로 순회를 하는 조건이 있기 때문에 응용된 문제였다.
- 색약이 아닌 사람의 경우, 각 색상(R, G, B)을 BFS로 탐색하여 구역을 찾는다. (R, G, B)
- 색약인 사람의 경우, R과 G를 동일하게 취급하여 BFS로 탐색하여 구역을 찾는다. (RG, B)