### PR TITLE
7주차 알고리즘 문제 풀이(1) - 송헌욱

### DIFF
--- a/src/heonuk/boj/sort_and_search/_1181/Main.java
+++ b/src/heonuk/boj/sort_and_search/_1181/Main.java
@@ -1,0 +1,42 @@
+package heonuk.boj.sort_and_search._1181;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class Main {
+
+    public static String solution(int N, String[] words) {
+        StringBuilder result = new StringBuilder();
+        Set<String> uniqueWords = new HashSet<>(List.of(words));
+
+        List<String> sortedWords = uniqueWords.stream()
+                .sorted((a, b) -> {
+                    if (a.length() == b.length()) { // 문자열 길이가 같은 경우
+                        return a.compareTo(b); // 사전 순으로
+                    } else { // 문자열 길이가 다른 경우
+                        return Integer.compare(a.length(), b.length()); // 길이 비교
+                    }
+                })
+                .collect(Collectors.toList());
+
+        for (String word : sortedWords) {
+            result.append(word).append("\n");
+        }
+        return result.toString();
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        String[] words = new String[N];
+        for (int i = 0; i < N; i++) {
+            words[i] = br.readLine();
+        }
+        System.out.println(solution(N, words));
+    }
+}

--- a/src/heonuk/boj/sort_and_search/_1822/Main.java
+++ b/src/heonuk/boj/sort_and_search/_1822/Main.java
@@ -1,0 +1,46 @@
+package heonuk.boj.sort_and_search._1822;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class Main {
+
+    public static String solution(int[] arrA, int[] arrB) {
+        StringBuilder result = new StringBuilder();
+
+        Set<Integer> setA = Arrays.stream(arrA)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        for (int num : arrB) {
+            setA.remove(num);
+        }
+
+        Set<Integer> sortedSet = new TreeSet<>(setA);
+
+        result.append(sortedSet.size()).append("\n");
+        for (int num : sortedSet) {
+            result.append(num).append(" ");
+        }
+
+        return result.toString();
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] input = br.readLine().split(" ");
+        int[] arrA = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        int[] arrB = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        System.out.println(solution(arrA, arrB));
+    }
+
+}

--- a/src/heonuk/boj/sort_and_search/_5648/Main.java
+++ b/src/heonuk/boj/sort_and_search/_5648/Main.java
@@ -1,0 +1,48 @@
+package heonuk.boj.sort_and_search._5648;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static long[] solution(int n, String[] strNum) {
+        long[] result = new long[n];
+
+        for (int i = 0; i < n; i++) {
+            String rev = new StringBuilder(strNum[i]).reverse().toString();
+            result[i] = Long.parseLong(rev);
+        }
+
+        Arrays.sort(result);
+
+        return result;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        String[] strNum = new String[n];
+        int idx = 0;
+
+        while (st.hasMoreTokens() && idx < n) {
+            strNum[idx++] = st.nextToken();
+        }
+
+        while (idx < n) {
+            st = new StringTokenizer(br.readLine());
+            while (st.hasMoreTokens() && idx < n) {
+                strNum[idx++] = st.nextToken();
+            }
+        }
+
+        for (long num : solution(n, strNum)) {
+            System.out.println(num);
+        }
+    }
+
+}


### PR DESCRIPTION
### 문제: BOJ5648. - 역원소 정렬
- 시간복잡도: **O(nlogn)**
  `Arrays.sort(result); `정렬은 nlogn의 시간복잡도를 가진다고 알고 있음.
- 문자열을 StringBuilder를 활용해서 뒤집고, 뒤집은 문자는 숫자로 변환하여 처리
- 오름차순 정렬을 위해 `Arrays.sort()` 메서드 사용

---

### 문제: BOJ1181 - 단어 정렬
- 시간복잡도: **O(nlogn)** 
  정렬의 시간 복잡도는 n log n 으로 알고 있음.
- Set을 통해 단어의 중복을 제거하고 stream()을 활용하여 정렬하는 방식으로 처리하였다.
- 정렬에 대한 요구사항이 주어진대로, 단어의 길이를 먼저 보고, 다음은 사전 순으로 정렬할 수 있도록 처리하였다.

---

### 문제: BOJ1822 - 차집합
- 시간복잡도: **O(nlogn)** 
  정렬의 시간 복잡도는 n log n 으로 알고 있음.
- 배열A와 배열B에서 기준을 배열 A 로 잡았고, 기준에서 중복된 요소가 있을 수 있기 때문에 이를 제거하기 위해 Set으로 변환하였다.
- 변환한 Set에서 배열B의 값을 제거해주면, 결과를 반환할 수 있었다.